### PR TITLE
DGCL document가 생기고 나서 TR 귀가피드백 작성 후 저장 안되는 문제 해결

### DIFF
--- a/zwontr/src/routes/TRedit.js
+++ b/zwontr/src/routes/TRedit.js
@@ -954,6 +954,9 @@ function TRedit() {
       if(!(textbookName in textbookIDMapping)) continue;
       const textbookID= textbookIDMapping[textbookName];
       if(!(textbookID in textbookIDToSavedGoalStateMapping)) continue;
+      // 만약 daily goal check log가 tr귀가검사 전에 생기고
+      // 그 다음에 같은 교재로 강의과제가 생기는 경우(자동으로 숨겨지게 돼있으므로) 학습시간 검사 안함
+      if(checkTextBookOfAssignment(textbookName)) continue; 
       if(textbookIDToSavedGoalStateMapping[textbookID]["finishedState"]===true){
         const textbookStudyTime= TR.학습[i].학습시간;
         if(textbookStudyTime==="0:00" || textbookStudyTime==="00:00") {

--- a/zwontr/src/routes/TRwrite.js
+++ b/zwontr/src/routes/TRwrite.js
@@ -1043,6 +1043,9 @@ function TRwrite() {
       if(!(textbookName in textbookIDMapping)) continue;
       const textbookID= textbookIDMapping[textbookName];
       if(!(textbookID in textbookIDToSavedGoalStateMapping)) continue;
+      // 만약 daily goal check log가 tr귀가검사 전에 생기고
+      // 그 다음에 같은 교재로 강의과제가 생기는 경우(자동으로 숨겨지게 돼있으므로) 학습시간 검사 안함
+      if(checkTextBookOfAssignment(textbookName)) continue;
       if(textbookIDToSavedGoalStateMapping[textbookID]["finishedState"]===true){
         const textbookStudyTime= TR.학습[i].학습시간;
         if(textbookStudyTime==="0:00" || textbookStudyTime==="00:00") {


### PR DESCRIPTION
해당 문제는 강의 과제에 사용된 교재가 TR 수업 및 진도 교재에도 있는 경우, 특히 DGCL document가 먼저 생기고 나서 TR 귀가 피드백 작성 후 저장 시에 발생함.
임시 방편으로 DGCL이 있지만 학습시간 입력 안 된 교재에 대해서 강의 과제에 사용된 경우 학습시간 검사 안하도록 변경