### PR TITLE
[bugFix] : TR & Student DB latest studyrate Bug

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -7,10 +7,7 @@
     <list default="true" id="b68b7d9e-ced1-47c4-a1d2-9c607a555e1e" name="Changes" comment="">
       <changelist_data name="taeho-han" email="oheat87@gmail.com" date="1676528121000" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/server/server.js" beforeDir="false" afterPath="$PROJECT_DIR$/server/server.js" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/zwontr/src/routes/StudentEdit.js" beforeDir="false" afterPath="$PROJECT_DIR$/zwontr/src/routes/StudentEdit.js" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/zwontr/src/routes/TRedit.js" beforeDir="false" afterPath="$PROJECT_DIR$/zwontr/src/routes/TRedit.js" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/zwontr/src/routes/TRwrite.js" beforeDir="false" afterPath="$PROJECT_DIR$/zwontr/src/routes/TRwrite.js" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,7 +6,11 @@
   <component name="ChangeListManager">
     <list default="true" id="b68b7d9e-ced1-47c4-a1d2-9c607a555e1e" name="Changes" comment="">
       <changelist_data name="taeho-han" email="oheat87@gmail.com" date="1676528121000" />
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/server/server.js" beforeDir="false" afterPath="$PROJECT_DIR$/server/server.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/zwontr/src/routes/StudentEdit.js" beforeDir="false" afterPath="$PROJECT_DIR$/zwontr/src/routes/StudentEdit.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/zwontr/src/routes/TRedit.js" beforeDir="false" afterPath="$PROJECT_DIR$/zwontr/src/routes/TRedit.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/zwontr/src/routes/TRwrite.js" beforeDir="false" afterPath="$PROJECT_DIR$/zwontr/src/routes/TRwrite.js" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />

--- a/server/server.js
+++ b/server/server.js
@@ -1145,7 +1145,10 @@ app.put("/api/Textbook", loginCheck, function (req, res) {
   }
   //const newTextbook = req.body;
   //const findID = ObjectId("62b815e210c04d831adf2f5b");
-  const edittedTextbook = req.body;
+  let edittedTextbook = req.body;
+
+  edittedTextbook["updatedAt"] = moment().format('YYYY-MM-DD HH:mm:SS')
+
   let findID;
   try {
     findID = new ObjectId(edittedTextbook["_id"]);

--- a/zwontr/src/routes/StudentEdit.js
+++ b/zwontr/src/routes/StudentEdit.js
@@ -191,6 +191,8 @@ function StudentEdit() {
       });
     setmanagerList(tmp);
 
+    console.log(newstuDB);
+
     newstuDB["진행중교재"].map((교재, index) => {
       교재["최근진도율"] = 교재["총교재량"] ? Math.round((교재["최근진도"] / parseInt(교재["총교재량"].match(/\d+/))) * 100) : 0;
     });

--- a/zwontr/src/routes/StudentEdit.js
+++ b/zwontr/src/routes/StudentEdit.js
@@ -191,7 +191,6 @@ function StudentEdit() {
       });
     setmanagerList(tmp);
 
-    console.log(newstuDB);
 
     newstuDB["진행중교재"].map((교재, index) => {
       교재["최근진도율"] = 교재["총교재량"] ? Math.round((교재["최근진도"] / parseInt(교재["총교재량"].match(/\d+/))) * 100) : 0;

--- a/zwontr/src/routes/TRedit.js
+++ b/zwontr/src/routes/TRedit.js
@@ -2609,7 +2609,7 @@ function TRedit() {
                             for (let i = 0; i < stuDB["진행중교재"].length; i++) {
                               for (let j = 0; j < TR["학습"].length; j++) {
                                 if (stuDB["진행중교재"][i]["과목"] == TR["학습"][j]["과목"] && stuDB["진행중교재"][i]["교재"] == TR["학습"][j]["교재"]) {
-                                  newstuDB["진행중교재"][i]["최근진도"] = Math.max(newstuDB["진행중교재"][i]["최근진도"], TR["학습"][j]["최근진도"]);
+                                  newstuDB["진행중교재"][i]["최근진도"] = TR["학습"][j]["최근진도"];
                                   newstuDB["진행중교재"][i]["최근진도율"] = newstuDB["진행중교재"][i]["총교재량"]
                                       ? Math.round((newstuDB["진행중교재"][i]["최근진도"] / parseInt(newstuDB["진행중교재"][i]["총교재량"].match(/\d+/))) * 100)
                                       : 0;

--- a/zwontr/src/routes/TRwrite.js
+++ b/zwontr/src/routes/TRwrite.js
@@ -2570,7 +2570,7 @@ function TRwrite() {
                      for (let i = 0; i < stuDB["진행중교재"].length; i++) {
                        for (let j = 0; j < TR["학습"].length; j++) {
                          if (stuDB["진행중교재"][i]["과목"] == TR["학습"][j]["과목"] && stuDB["진행중교재"][i]["교재"] == TR["학습"][j]["교재"]) {
-                          newstuDB["진행중교재"][i]["최근진도"] = Math.max(newstuDB["진행중교재"][i]["최근진도"], TR["학습"][j]["최근진도"]);
+                          newstuDB["진행중교재"][i]["최근진도"] = TR["학습"][j]["최근진도"];
                           newstuDB["진행중교재"][i]["최근진도율"] = newstuDB["진행중교재"][i]["총교재량"]
                               ? Math.round((newstuDB["진행중교재"][i]["최근진도"] / parseInt(newstuDB["진행중교재"][i]["총교재량"].match(/\d+/))) * 100)
                               : 0;


### PR DESCRIPTION
### description

- Student DB와 학생TR에서 표시되는 학생의 최근 진도량이 입력된 두 필드값 중 가장 큰 것만 가져오는 현상 해결
- 교재 관리 페이지에서 언제 수정되었는지 확인하는 updatedAt 필드 추가 로직 구현

### Work Flow

- [x] TR Edit/Wirte 에서 최근 진도 저장 중 Math.max 명령어 제거 + 현재 입력된 값을 기준으로 필드에 추가하도록 구현
- [x] PUT /api/Textbook 에서 edittedTextbook 데이터에 updatedAt 필드를 추가하고 요청 시각을 값으로 넣도록 구현

### BreakChange
X 